### PR TITLE
Update tableData.json

### DIFF
--- a/data/tableData.json
+++ b/data/tableData.json
@@ -201,7 +201,7 @@
   },
   {
     "letter": "A",
-    "name": "埃索美拉唑镁肠溶片",
+    "name": "艾司奥美拉唑镁肠溶片",
     "brandName": "耐信",
     "manufacturer": "阿斯利康制药有限公司",
     "tags": [


### PR DESCRIPTION
耐信的“埃索美拉唑镁肠溶片”已更名为“艾司奥美拉唑镁肠溶片”。
https://www.nmpa.gov.cn/datasearch/search-info.html?nmpa=aWQ9OGY0YmQwZjY0MDgxZTEwMGVjYzE2MTkwZTE4ZDQ1YWUmaXRlbUlkPWZmODA4MDgxODNjYWQ3NTAwMTg0MDg4MWY4NDgxNzlm