### PR TITLE
update 枸橼酸莫沙必利片的商品名称和生产厂家

### DIFF
--- a/data/tableData.json
+++ b/data/tableData.json
@@ -946,7 +946,8 @@
   {
     "letter": "J",
     "name": "枸橼酸莫沙必利片",
-    "manufacturer": "大日本制药株式会社 (Dainippon Sumitomo Pharma Co.)",
+    "brandName": "加斯清",
+    "manufacturer": "住友制药株式会社 (Sumitomo Pharma Co., Ltd)",
     "tags": [
       "消化系统用药",
       "片剂"


### PR DESCRIPTION
参考维基百科 https://zh.wikipedia.org/wiki/%E8%8E%AB%E6%B2%99%E5%BF%85%E5%88%A9 和 https://zh.wikipedia.org/wiki/%E4%BD%8F%E5%8F%8B%E5%88%B6%E8%8D%AF  2005年大日本制药株式会社和日本住友制药株式会社合并为了住友制药